### PR TITLE
Add join option when starting nodes

### DIFF
--- a/lib/ex_unit_cluster/manager.ex
+++ b/lib/ex_unit_cluster/manager.ex
@@ -79,6 +79,14 @@ defmodule ExUnitCluster.Manager do
         ]
       })
 
+    if join do
+      for %NodeInfo{join: node_join, pid: node_pid} <- Map.values(state.nodes) do
+        if node_join do
+          peer_call(node_pid, Node, :connect, [node])
+        end
+      end
+    end
+
     peer_call(pid, :code, :add_paths, [:code.get_path()])
 
     for {app, _, _} <- Application.loaded_applications() do
@@ -102,14 +110,6 @@ defmodule ExUnitCluster.Manager do
     else
       app = Mix.Project.config()[:app]
       peer_call(pid, Application, :ensure_all_started, [app])
-    end
-
-    if join do
-      for %NodeInfo{join: node_join, pid: node_pid} <- Map.values(state.nodes) do
-        if node_join do
-          peer_call(node_pid, Node, :connect, [node])
-        end
-      end
     end
 
     node_info = %NodeInfo{pid: pid, join: join}

--- a/test/start_node_opts_test.exs
+++ b/test/start_node_opts_test.exs
@@ -11,4 +11,64 @@ defmodule StartNodeOptsTest do
 
     assert node_self == node
   end
+
+  test "do not automatically join nodes together", %{cluster: cluster} do
+    node1 = ExUnitCluster.start_node(cluster, join: false)
+    node2 = ExUnitCluster.start_node(cluster, join: false)
+
+    node3 = ExUnitCluster.start_node(cluster)
+    node4 = ExUnitCluster.start_node(cluster, join: true)
+
+    # Node1 and Node2 are not in the cluster
+    node1_cluster_nodes =
+      in_cluster cluster, node1 do
+        Node.list([:visible, :hidden, :connected, :this])
+      end
+
+    node2_cluster_nodes =
+      in_cluster cluster, node2 do
+        Node.list([:visible, :hidden, :connected, :this])
+      end
+
+    assert length(node1_cluster_nodes) == 1
+    assert length(node2_cluster_nodes) == 1
+    refute node1_cluster_nodes == node2_cluster_nodes
+
+    # Node3 and Node4 are in a cluster together
+    node3_cluster_nodes =
+      in_cluster cluster, node3 do
+        Node.list([:visible, :hidden, :connected, :this])
+      end
+      |> Enum.sort()
+
+    node4_cluster_nodes =
+      in_cluster cluster, node4 do
+        Node.list([:visible, :hidden, :connected, :this])
+      end
+      |> Enum.sort()
+
+    assert length(node3_cluster_nodes) == 2
+    assert length(node4_cluster_nodes) == 2
+    assert node3_cluster_nodes == node4_cluster_nodes
+
+    ExUnitCluster.call(cluster, node1, Node, :connect, [node3])
+    ExUnitCluster.call(cluster, node1, Node, :connect, [node4])
+
+    # We can join Node1 manually to the cluster
+    node1_cluster_nodes =
+      in_cluster cluster, node1 do
+        Node.list([:visible, :hidden, :connected, :this])
+      end
+      |> Enum.sort()
+
+    node3_cluster_nodes =
+      in_cluster cluster, node3 do
+        Node.list([:visible, :hidden, :connected, :this])
+      end
+      |> Enum.sort()
+
+    assert length(node1_cluster_nodes) == 3
+    assert length(node3_cluster_nodes) == 3
+    assert node1_cluster_nodes == node3_cluster_nodes
+  end
 end


### PR DESCRIPTION
Add `join` option to `start_node/2` to enable the scenarios specified in: #1 

If a node is started with 
```elixir
    node = ExUnitCluster.start_node(cluster, join: false)
```
Then it is not automatically joined to the cluster, and subsequent nodes that are started, do not automatically join it either.