### PR TITLE
Add option to override Application env on start_node

### DIFF
--- a/lib/ex_unit_cluster/manager.ex
+++ b/lib/ex_unit_cluster/manager.ex
@@ -90,7 +90,15 @@ defmodule ExUnitCluster.Manager do
     peer_call(pid, :code, :add_paths, [:code.get_path()])
 
     for {app, _, _} <- Application.loaded_applications() do
-      for {key, val} <- Application.get_all_env(app) do
+      base_env = Application.get_all_env(app)
+
+      environment =
+        opts
+        |> Keyword.get(:environment, [])
+        |> Keyword.get(app, [])
+        |> Keyword.merge(base_env, fn _, v, _ -> v end)
+
+      for {key, val} <- environment do
         peer_call(pid, Application, :put_env, [app, key, val])
       end
     end

--- a/test/start_node_env_override_test.exs
+++ b/test/start_node_env_override_test.exs
@@ -1,0 +1,52 @@
+defmodule StartNodeEnvOverrideTest do
+  use ExUnit.Case
+
+  @app :ex_unit_cluster
+  @key_a_original 123_456
+  @key_b_original "B_VALUE"
+
+  setup ctx do
+    original_env = Application.get_all_env(@app)
+
+    Application.put_env(@app, :key_a, @key_a_original)
+    Application.put_env(@app, :key_b, @key_b_original)
+
+    on_exit(fn ->
+      original_env
+      |> Enum.each(fn {key, value} -> Application.put_env(@app, key, value) end)
+    end)
+
+    cluster = start_supervised!({ExUnitCluster.Manager, ctx})
+
+    [cluster: cluster]
+  end
+
+  describe ":environment option used with start_node/2" do
+    setup [:start_nodes]
+
+    test "application env is overriden for node using option", ctx do
+      %{cluster: cluster, node1: node1} = ctx
+
+      node1_env = ExUnitCluster.call(cluster, node1, Application, :get_all_env, [@app])
+
+      assert 777 == Keyword.get(node1_env, :key_a)
+      assert @key_b_original == Keyword.get(node1_env, :key_b)
+    end
+
+    test "application env is unchanged for nodes not using option", ctx do
+      %{cluster: cluster, node2: node2} = ctx
+
+      node2_env = ExUnitCluster.call(cluster, node2, Application, :get_all_env, [@app])
+
+      assert @key_a_original == Keyword.get(node2_env, :key_a)
+      assert @key_b_original == Keyword.get(node2_env, :key_b)
+    end
+  end
+
+  defp start_nodes(%{cluster: cluster}) do
+    node1 = ExUnitCluster.start_node(cluster, environment: [{@app, [key_a: 777]}])
+    node2 = ExUnitCluster.start_node(cluster)
+
+    [node1: node1, node2: node2]
+  end
+end


### PR DESCRIPTION
This change adds an `:environment` option to `start_node/2` allowing the application environment of the new node to be overridden with specified values before applications are started.

The value of `:environment` options key is a keyword list, the keys being application names and the values being keyword lists for the env key/values to be overridden.

```ex
ExUnitCluster.start_node(cluster, [
  environment: [
    my_app: [
      port: 4444
    ]
  ]
])
```