### PR TITLE
Add in_cluster_env macro that captures callers env

### DIFF
--- a/lib/ex_unit_cluster.ex
+++ b/lib/ex_unit_cluster.ex
@@ -47,7 +47,7 @@ defmodule ExUnitCluster do
 
   @doc """
   Execute multiline code blocks on a specific node,
-  inheriting environment variables from the caller.
+  capturing variables from the caller scope.
   """
   defmacro in_cluster_env(cluster, node, do: expressions) do
     # We need a consistent random name, as this is compiled

--- a/lib/ex_unit_cluster.ex
+++ b/lib/ex_unit_cluster.ex
@@ -65,6 +65,7 @@ defmodule ExUnitCluster do
         import ExUnit.Assertions
 
         def run(unquote(env)) do
+          _ = unquote(env)
           unquote(expressions)
         end
       end

--- a/test/multiline_in_cluster_test.exs
+++ b/test/multiline_in_cluster_test.exs
@@ -24,4 +24,17 @@ defmodule MultilineInClusterTest do
 
     refute res_one == res_two
   end
+
+  test "in_cluster_env macro inherits environment variables of caller", %{cluster: cluster} do
+    n1 = ExUnitCluster.start_node(cluster)
+
+    caller_variable = "expected"
+
+    result =
+      in_cluster_env cluster, n1 do
+        caller_variable
+      end
+
+    assert caller_variable == result
+  end
 end


### PR DESCRIPTION
Adds a macro `in_cluster_env`, that captures the variables from the __CALLER__ env into the macro