### PR TITLE
Avoid macros redefining modules

### DIFF
--- a/lib/ex_unit_cluster.ex
+++ b/lib/ex_unit_cluster.ex
@@ -29,16 +29,17 @@ defmodule ExUnitCluster do
     # on each node separately at the moment.
     module_name = :"#{:erlang.phash2(expressions)}"
 
-    quoted =
-      quote do
-        import ExUnit.Assertions
+    if :code.module_status(module_name) == :not_loaded do
+      quoted =
+        quote do
+          import ExUnit.Assertions
 
-        def run do
-          unquote(expressions)
+          def run do
+            unquote(expressions)
+          end
         end
-      end
-
-    Module.create(module_name, quoted, Macro.Env.location(__ENV__))
+      Module.create(module_name, quoted, Macro.Env.location(__ENV__))
+    end
 
     quote do
       ExUnitCluster.call(unquote(cluster), unquote(node), unquote(module_name), :run, [])
@@ -60,17 +61,19 @@ defmodule ExUnitCluster do
       |> Keyword.keys()
       |> Enum.map(&Macro.var(&1, nil))
 
-    quoted =
-      quote do
-        import ExUnit.Assertions
+    if :code.module_status(module_name) == :not_loaded do
+      quoted =
+        quote do
+          import ExUnit.Assertions
 
-        def run(unquote(env)) do
-          _ = unquote(env)
-          unquote(expressions)
+          def run(unquote(env)) do
+            _ = unquote(env)
+            unquote(expressions)
+          end
         end
-      end
 
-    Module.create(module_name, quoted, Macro.Env.location(__ENV__))
+      Module.create(module_name, quoted, Macro.Env.location(__ENV__))
+    end
 
     quote do
       ExUnitCluster.call(unquote(cluster), unquote(node), unquote(module_name), :run, [

--- a/lib/ex_unit_cluster.ex
+++ b/lib/ex_unit_cluster.ex
@@ -47,7 +47,7 @@ defmodule ExUnitCluster do
 
   @doc """
   Execute multiline code blocks on a specific node,
-  inheriting environment variables from the caller.
+  capturing variables from the caller scope.
   """
   defmacro in_cluster_env(cluster, node, do: expressions) do
     # We need a consistent random name, as this is compiled

--- a/lib/ex_unit_cluster.ex
+++ b/lib/ex_unit_cluster.ex
@@ -38,6 +38,7 @@ defmodule ExUnitCluster do
             unquote(expressions)
           end
         end
+
       Module.create(module_name, quoted, Macro.Env.location(__ENV__))
     end
 

--- a/lib/ex_unit_cluster.ex
+++ b/lib/ex_unit_cluster.ex
@@ -65,6 +65,7 @@ defmodule ExUnitCluster do
         import ExUnit.Assertions
 
         def run(unquote(env)) do
+          _ = unquote(env)
           unquote(expressions)
         end
       end

--- a/test/multiline_in_cluster_test.exs
+++ b/test/multiline_in_cluster_test.exs
@@ -24,4 +24,17 @@ defmodule MultilineInClusterTest do
 
     refute res_one == res_two
   end
+
+  test "in_cluster_env macro inherits environment variables of caller", %{cluster: cluster} do
+    n1 = ExUnitCluster.start_node(cluster)
+
+    caller_variable = "expected"
+
+    result =
+      in_cluster_env cluster, n1 do
+        caller_variable
+      end
+
+    assert caller_variable == result
+  end
 end


### PR DESCRIPTION
In cases where a macro is copy-pasted, or tests are generated with iterators, "redefining module" warnings are thrown. 
In this PR we check if the module already exists, before creating it.